### PR TITLE
Updated Drop.ts

### DIFF
--- a/src/network/actions/Drop.ts
+++ b/src/network/actions/Drop.ts
@@ -9,6 +9,13 @@ export class Drop {
 
   public async execute(action: NonEmptyObject<{ itemID: string }>): Promise<void> {
     const itemID = parseInt(action.itemID);
+
+    // Prevent dropping specific items add to the list if you want to prevent more items
+    if (itemID === 18 || itemID === 32) {
+      this.peer.send(Variant.from("OnConsoleMessage", "You'd be sorry if you lost that."));
+      return;
+    }
+
     const item = this.base.items.metadata.items.find((v) => v.id === itemID);
 
     const peerItem = this.peer.data.inventory.items.find((v) => v.id === itemID);


### PR DESCRIPTION
I have added the function to not allow the player to drop the Fist and Wrench as well as letting it be expandable via item ids

`  public async execute(action: NonEmptyObject<{ itemID: string }>): Promise<void> {
    const itemID = parseInt(action.itemID);

    // Prevent dropping specific items add to the list if you want to prevent more items
    if (itemID === 18 || itemID === 32) {
      this.peer.send(Variant.from("OnConsoleMessage", "You cannot drop this item."));
      return;
    }`
    
    

https://github.com/user-attachments/assets/4740c138-f6f2-44fd-946d-327b619d8db5

