### PR TITLE
Items drop from blocks and Seed Splicing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ lerna-debug.log*
 *.sw?
 
 items_info_new.json
+.vs/

--- a/src/core/Peer.ts
+++ b/src/core/Peer.ts
@@ -266,6 +266,9 @@ export class Peer extends OldPeer<PeerData> {
   }
 
   public removeItemInven(id: number, amount = 1) {
+    if (id === 0 || id === -1 || id === 32 || id === 18) {
+      return;
+    }
     const item = this.data.inventory.items.find((i) => i.id === id);
 
     if (item) {

--- a/src/network/tanks/TileChangeReq.ts
+++ b/src/network/tanks/TileChangeReq.ts
@@ -637,6 +637,15 @@ export class TileChangeReq {
 
     this.block.rotatedLeft = undefined;
 
+    this.world.drop(
+      this.peer,
+      this.block.x * 32 + Math.floor(Math.random() * 16),
+      this.block.y * 32 + Math.floor(Math.random() * 16),
+      this.randomizeDrop(this.itemMeta.id ?? -1) ?? 0,
+      1,
+      { tree: true }
+    );
+
     switch (this.itemMeta.type) {
       case ActionTypes.PORTAL:
       case ActionTypes.DOOR:
@@ -707,6 +716,20 @@ export class TileChangeReq {
         }
         break;
       }
+    }
+  }
+  
+  private randomizeDrop(id: number) {
+    if (id === -1) {
+      return 0; // was -1. block with id -1 can drop but when you will enter world with this dropped -1 id block it will throw an error 
+    }
+    const rand = Math.random();
+    if (rand < 0.6) {
+      return id;
+    } else if (rand < 0.8) {
+      return id + 1;
+    } else {
+      return 0; 
     }
   }
 

--- a/src/types/misc.d.ts
+++ b/src/types/misc.d.ts
@@ -15,7 +15,7 @@ export interface Cache {
 }
 
 export interface ItemsInfo {
-  id: number;
+  id: any;
   name: string;
   desc: string;
   recipe?: Recipe;


### PR DESCRIPTION
# # Items drop from blocks
Now seeds and blocks can drop from destroyed blocks (randomness still needs to be replicated from rgt)
There's a bug when you can pick up blank
https://github.com/user-attachments/assets/787f9f48-e5d1-4dc9-b79d-ad67f9b29f48

## Splicing
Splicing is now working but with some known bugs:
- Can place seeds on foreground blocks (not trees)
- Can splice with already grown tree (because it uses TileChangedReq.ts/onFistDestroyedTree())
- When splicing there's punch particle

https://github.com/user-attachments/assets/3d8ea9dd-ec1b-4606-9abf-2021e0d42cae

