### PR TITLE
fix(network): serve raw items.dat from disk to prevent byte offset shifts

### DIFF
--- a/apps/server/src/network/actions/RefreshItemData.ts
+++ b/apps/server/src/network/actions/RefreshItemData.ts
@@ -20,18 +20,19 @@ export class RefreshItemData {
     const isMacOS = this.peer.data.platformID === "2";
 
     let itemsContent: Buffer;
+    const datDir = join(process.cwd(), ".cache", "growtopia", "dat");
 
     if (isMacOS) {
-      // Load macOS items.dat at runtime
-      const datDir = join(process.cwd(), ".cache", "growtopia", "dat");
+      // macOS read raw file
       const macosItemsDatName = this.base.cdn.itemsDatName.replace(
         ".dat",
         "-osx.dat",
       );
       itemsContent = readFileSync(join(datDir, macosItemsDatName));
     } else {
-      // Use regular items.dat already loaded in memory
-      itemsContent = this.base.items.content;
+      // WINDOWS/ANDROID RAW FILE READ
+      // Parse won't fuck file (1 byte)
+      itemsContent = readFileSync(join(datDir, this.base.cdn.itemsDatName));
     }
 
     this.peer.send(


### PR DESCRIPTION
Fixes the annoying "download failed" error and the malformed CDN requests on v5.56 and v5.57.

Basically, RefreshItemData.ts was using the reconstructed in-memory buffer (this.base.items.content) for Windows/Android clients. It looks like our internal parser drops a byte when re-encoding (probably missing a new struct flag in 5.56 and v5.57), which causes a 1-byte offset shift on the client side. This is why the client was trying to request item description strings instead of actual texture paths from the CDN (like GET /growtopia/hip can survive...).

This PR just changes it so we serve the raw items.dat straight from the disk for all platforms, exactly like we were already doing for macOS. Bypassing the in-memory re-encoding completely solves the shift and the download errors.

Code changes:
Changed RefreshItemData.ts to use readFileSync(join(datDir, this.base.cdn.itemsDatName)) for the fallback case instead of this.base.items.content.